### PR TITLE
ジャンルをボタンとして一覧表示すためにgenreコンポーネントを作成

### DIFF
--- a/src/Genre.js
+++ b/src/Genre.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+import ButtonKit from './uikit/ButtonKit'
+const Ganre = () => {
+
+    const [genres,setGenres]=useState([])
+
+
+
+    useEffect(()=>{
+        fetch('http://web-tas.net/shop/genru.php')
+               .then((response)=>{
+                   return response.json()
+               }).then(json =>{
+                   setGenres(json.results.genre)
+               })
+    },[])   
+
+    return(
+        <>
+            {
+                 genres.map(genre=>{
+                    return <ButtonKit label={genre.name} onClick={()=>console.log(genre.name)} key={genre.code}/>
+                 })
+            }
+        </>
+    )
+}
+
+export default Ganre


### PR DESCRIPTION
## Issue

Closes #<Issue の番号>

## 今回の PR で行ったこと

fetchでAPIを叩き、取得したデータを一度useState(genrus)の配列の中に入れて、それらをmapで回しながら、ボタンコンポーネントに落とし込んだ、onClickの関数についてはまだ未定義なので、現状では、クリックしたボタンの名前をコンソール上に表示する形で仮実装している

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

Appコンポーネントにの直下に貼り付けて各ボタンの表示とクリック時の動作をチェックする。

## 確認して欲しいところ
今回このコンポーネントにはスタイルはあえて当てていません。
理由はスタイルを当てて配置を整頓するコンポーネントを作成し、それを親に設定してある程度共通化した画面描画を目指した方が良いのでは考えたからです！
上記について意見やアドバイス、他の案が会ったらスラックの方にお願いします
## 懸念点
スタイルが当たっていないためボタンの配置がおかしい
